### PR TITLE
expose to commonJS, node, component.io

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "rgbquant",
-  "repository": "forresto/RgbQuant.js",
+  "repository": "leeoniya/RgbQuant.js",
   "version": "1.0.0",
   "dependencies": {
   },

--- a/component.json
+++ b/component.json
@@ -1,0 +1,14 @@
+{
+  "name": "RgbQuant.js",
+  "repository": "forresto/RgbQuant.js",
+  "version": "1.0.0",
+  "dependencies": {
+  },
+  "main": "src/rgbquant.js",
+  "scripts": [
+    "src/rgbquant.js"
+  ],
+  "remotes": [
+    "https://raw.githubusercontent.com"
+  ]
+}

--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
-  "name": "RgbQuant.js",
+  "name": "rgbquant",
   "repository": "forresto/RgbQuant.js",
   "version": "1.0.0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/rgbquant.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/forresto/RgbQuant.js.git"
+    "url": "git://github.com/leeoniya/RgbQuant.js.git"
   },
   "bugs": {
     "url": "https://github.com/leeoniya/RgbQuant.js/issues"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "RgbQuant.js",
+  "description": "color quantization lib http://o-0.me/RgbQuant/",
+  "author": "https://github.com/leeoniya",
+  "version": "1.0.0",
+  "main": "src/rgbquant.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/forresto/RgbQuant.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/leeoniya/RgbQuant.js/issues"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "RgbQuant.js",
+  "name": "rgbquant",
   "description": "color quantization lib http://o-0.me/RgbQuant/",
   "author": "https://github.com/leeoniya",
   "version": "1.0.0",

--- a/src/rgbquant.js
+++ b/src/rgbquant.js
@@ -834,6 +834,7 @@
 				can.height = img.naturalHeight;
 				ctx = can.getContext("2d");
 				ctx.drawImage(img,0,0);
+			case "Canvas":
 			case "HTMLCanvasElement":
 				can = can || img;
 				ctx = ctx || can.getContext("2d");

--- a/src/rgbquant.js
+++ b/src/rgbquant.js
@@ -916,4 +916,9 @@
 	// expose
 	this.RgbQuant = RgbQuant;
 
+	// expose to commonJS
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = RgbQuant;
+	}
+
 }).call(this);


### PR DESCRIPTION
Re: #6

This makes RgbQuant.js work in node when passing in a https://github.com/Automattic/node-canvas object. 